### PR TITLE
Support multiple doors separately

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /secret.php
+bitraf-door-credentials.sh
 .*.sw?

--- a/bitraf-door-credentials.sh.example
+++ b/bitraf-door-credentials.sh.example
@@ -1,0 +1,3 @@
+export MQTT_USERNAME=fooo
+export MQTT_PASSWORD=baar
+export MQTT_BROKER=mqtt.bitraf.no

--- a/bitraf-door-open.sh
+++ b/bitraf-door-open.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+LOGIN_NAME=$1
+DOOR=$2
+DURATION=$3
+
+# Sanity checks
+case "$DOOR" in
+  frontdoor) ;;
+  2floor) ;;
+  4floor) ;;
+  3office) ;;
+  3floor) ;;
+  *)
+    echo "Unsupported door value \"$DOOR\""
+    exit 1
+esac
+
+source ./bitraf-door-credentials.sh
+
+# Trigger unlocking
+mosquitto_pub -h $MQTT_BROKER -u $MQTT_USERNAME -P $MQTT_PASSWORD -t "/bitraf/door/$DOOR/open" -m "$DURATION"
+
+# Notify that member logged in
+mosquitto_pub -h $MQTT_BROKER -t /bitraf/doorweb/memberlogin -m "$LOGIN_NAME"

--- a/index.php
+++ b/index.php
@@ -188,7 +188,7 @@ else if ($rate_limited)
 flush();
 
 function unlock($door, $duration) {
-  $script = '/usr/local/bin/bitraf-door-open.sh';
+  $script = './bitraf-door-open.sh';
   $command = $script . ' ' . escapeshellarg($_POST['user']) .
                        ' ' . escapeshellarg($door) .
                        ' ' . escapeshellarg($duration) .

--- a/index.php
+++ b/index.php
@@ -27,6 +27,11 @@ if (isset($_POST['action'])
   require_once('db-connect-string.php');
   pg_connect($db_connect_string);
 
+  if (!isset($_POST['door'])) {
+    // Default to old behavior
+    $_POST['door'] = 'frontdoor-2floor';
+  }
+
   // Per-IP failure rate limit.
   $res = pg_query_params("SELECT COUNT(*) FROM auth_log WHERE host = $1 AND account IS NULL AND date > NOW() - INTERVAL '1 hour'", array($_SERVER['REMOTE_ADDR']));
   $fail_count = pg_fetch_result($res, 0, 0);
@@ -141,6 +146,7 @@ else if ($rate_limited)
 	
     <form method=post action='<?=htmlentities($_SERVER['REQUEST_URI'], ENT_QUOTES, 'UTF-8')?>'>
       <input type=hidden name=action value=unlock>
+      <input type=hidden name=door value='invalid'>
 	  
 	  <h4>Authentication</h4>  
 	  <div class='form-group'>	  
@@ -158,10 +164,17 @@ else if ($rate_limited)
 	</div>
 	
 	<div class='container' style='margin-top: 30px; margin-bottom: 200px;'>
-    <button type='submit' class='btn btn-lg btn-success' style='padding: 20px 50px 20px 50px;' value='Unlock'>
+
+    <button type='submit' class='btn btn-lg btn-success' value='frontdoor-2floor' onclick="this.form.door.value=this.value">
 		<span class='glyphicon glyphicon-lock' style='margin-right: 0px;'></span>
-		Unlock
-	</button>
+    Frontdoor & lab
+	  </button>
+
+    <button type='submit' class='btn btn-lg btn-success' value='4floor' onclick="this.form.door.value=this.value">
+		<span class='glyphicon glyphicon-lock' style='margin-right: 0px;'></span>
+		4th floor
+	  </button>
+
 	</div>
 	
     </form>
@@ -174,5 +187,20 @@ else if ($rate_limited)
 // has rendered to prevent its slowness from stalling the web browser.
 flush();
 
-if ($ok)
-  system('/usr/local/bin/bitraf-door-open.sh '.escapeshellarg($_POST['user']));
+function unlock($door, $duration) {
+  $script = '/usr/local/bin/bitraf-door-open.sh';
+  $command = $script . ' ' . escapeshellarg($_POST['user']) .
+                       ' ' . escapeshellarg($door) .
+                       ' ' . escapeshellarg($duration) .
+                       ' 2>&1';
+  exec($command, $output, $retval);
+}
+
+if ($ok) {
+  if ($_POST['door'] === 'frontdoor-2floor') {
+    unlock('frontdoor', 10);
+    unlock('2floor', 60);
+  } else {
+    unlock($_POST['door'], 10);
+  }
+}

--- a/style/main.css
+++ b/style/main.css
@@ -13,3 +13,9 @@ p {
 input {
   margin-bottom: 10px;
 }
+
+.btn-lg {
+  width: 100%;
+  margin-bottom: 20px;
+  padding: 20px 50px 20px 50px;
+}


### PR DESCRIPTION

In the UI and on MQTT level. This is especially preparing for additional doorlocks on 3rd floor.

Authentication and auth log is still done against one single 'door' realm, regardless of which door(s) are opened.

Has been tested in the production environment.

![bitraf-door-multi](https://user-images.githubusercontent.com/45185/28100199-f828b06e-66c0-11e7-8c77-f361e289a01a.png)